### PR TITLE
Patch 10.0.0 Compatibility Fix

### DIFF
--- a/BuyEmAll/BuyEmAll.toc
+++ b/BuyEmAll/BuyEmAll.toc
@@ -1,4 +1,4 @@
-## Interface: 90205
+## Interface: 100000
 ## Author: Jordy141
 ## Notes: Enhances shift-click interface at vendors, making it easier to buy large amounts of items at once.
 ## Title: BuyEmAll

--- a/BuyEmAll/BuyEmAll.xml
+++ b/BuyEmAll/BuyEmAll.xml
@@ -184,11 +184,6 @@
 						<Offset x="2" y="-45" />
 					</Anchor>
 				</Anchors>
-				<Backdrop bgFile="" edgeFile="">
-					<BackgroundInsets>
-						<AbsInset left="0" right="0" top="0" bottom="0" />
-					</BackgroundInsets>
-				</Backdrop>
 				<Layers>
 					<Layer>
 						<Texture name="BuyEmAllCurrency1" file="nil">


### PR DESCRIPTION
This one is compatible with patch 10.0.0 but not 10.0.2 because of [Patch 10.0.2 API changes](https://wowpedia.fandom.com/wiki/Patch_10.0.2/API_changes). That'll require another minor fix.
The problematic `<Backdrop>` is removed in [Patch 9.0.1](https://github.com/Stanzilla/WoWUIBugs/wiki/9.0.1-Consolidated-UI-Changes#backdrop-system-changes) and does not seem to affect functionality anyway.